### PR TITLE
Modified KineticaContainer to extend JdbcDatabaseContainer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
             <artifactId>kinetica-jdbc</artifactId>
             <classifier>jar-with-dependencies</classifier>
             <version>${kinetica-jdbc.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- HikariCP -->
@@ -116,22 +117,6 @@
                 <configuration>
                     <source>17</source>
                     <target>17</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
-                <configuration>
-                    <archive>
-                        <index>true</index>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <addExtensions>false</addExtensions>
-                        </manifest>
-                    </archive>
-                    <finalName>${project.name}</finalName>
-                    <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/kinetica/containers/KineticaContainer.java
+++ b/src/main/java/org/kinetica/containers/KineticaContainer.java
@@ -6,7 +6,7 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.util.Set;
 
-public class KineticaContainer<SELF extends KineticaContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+public class KineticaContainer extends JdbcDatabaseContainer<KineticaContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("kinetica/kinetica-intel");
 
@@ -23,14 +23,6 @@ public class KineticaContainer<SELF extends KineticaContainer<SELF>> extends Jdb
     private String username = DEFAULT_USER;
 
     private String password = DEFAULT_PASSWORD;
-
-    /**
-     * @deprecated use {@link KineticaContainer(DockerImageName)} instead
-     */
-    @Deprecated
-    public KineticaContainer() {
-        this(DEFAULT_IMAGE_NAME.withTag(DEFAULT_TAG));
-    }
 
     public KineticaContainer(String dockerImageName) {
         this(DockerImageName.parse(dockerImageName));
@@ -98,19 +90,19 @@ public class KineticaContainer<SELF extends KineticaContainer<SELF>> extends Jdb
     }
 
     @Override
-    public SELF withDatabaseName(final String databaseName) {
+    public KineticaContainer withDatabaseName(final String databaseName) {
         this.databaseName = databaseName;
         return self();
     }
 
     @Override
-    public SELF withUsername(final String username) {
+    public KineticaContainer withUsername(final String username) {
         this.username = username;
         return self();
     }
 
     @Override
-    public SELF withPassword(final String password) {
+    public KineticaContainer withPassword(final String password) {
         this.password = password;
         return self();
     }

--- a/src/test/java/org/kinetica/containers/AbstractContainerBaseTest.java
+++ b/src/test/java/org/kinetica/containers/AbstractContainerBaseTest.java
@@ -14,11 +14,11 @@ public abstract class AbstractContainerBaseTest {
     private static final String PWD = "admin";
 
     static {
-        kineticaContainer = new KineticaContainer<>(KINETICA_INTEL_LATEST_IMAGE)
-                .withInitScript("somepath/init_kinetica.sql")
-                .withUsername(USER)
-                .withPassword(PWD)
-                .withLogConsumer(new Slf4jLogConsumer(logger));
+        kineticaContainer = new KineticaContainer(KINETICA_INTEL_LATEST_IMAGE);
+        kineticaContainer.withInitScript("somepath/init_kinetica.sql");
+        kineticaContainer.withUsername(USER);
+        kineticaContainer.withPassword(PWD);
+        kineticaContainer.withLogConsumer(new Slf4jLogConsumer(logger));
         kineticaContainer.addEnv("FULL_START", "1");
 
         long start = System.currentTimeMillis();

--- a/src/test/java/org/kinetica/containers/KineticaContainerTest.java
+++ b/src/test/java/org/kinetica/containers/KineticaContainerTest.java
@@ -13,7 +13,7 @@ public class KineticaContainerTest {
 
     @Test
     public void containerStarted() {
-        try (KineticaContainer<?> kineticaContainer = new KineticaContainer<>(KINETICA_INTEL_LATEST_IMAGE)) {
+        try (KineticaContainer kineticaContainer = new KineticaContainer(KINETICA_INTEL_LATEST_IMAGE)) {
             kineticaContainer.addEnv("FULL_START", "0");
             kineticaContainer.waitingFor(new WaitAllStrategy().withStartupTimeout(Duration.of(30, ChronoUnit.SECONDS)));
             kineticaContainer.start();


### PR DESCRIPTION
- Modified KineticaContainer to extend JdbcDatabaseContainer.
- Changed scope of kinetica-jdbc dependency to runtime.
- Removed maven-jar-plugin from pom.
- Removed default constructor, Kinetica Docker image name must now be provided.